### PR TITLE
Incorrect parameters when using PredicateBuilder extension methods with Invoke()

### DIFF
--- a/src/PredicateBuilder.cs
+++ b/src/PredicateBuilder.cs
@@ -16,7 +16,7 @@ namespace LinqKit
 		public static Expression<Func<T, bool>> Or<T> (this Expression<Func<T, bool>> expr1,
 												  Expression<Func<T, bool>> expr2)
 		{
-			var invokedExpr = Expression.Invoke (expr2, expr1.Parameters.Cast<Expression> ());
+			var invokedExpr = Expression.Invoke (expr2.Expand(), expr1.Parameters.Cast<Expression> ());
 			return Expression.Lambda<Func<T, bool>>
 				 (Expression.OrElse (expr1.Body, invokedExpr), expr1.Parameters);
 		}
@@ -24,7 +24,7 @@ namespace LinqKit
 		public static Expression<Func<T, bool>> And<T> (this Expression<Func<T, bool>> expr1,
 												   Expression<Func<T, bool>> expr2)
 		{
-			var invokedExpr = Expression.Invoke (expr2, expr1.Parameters.Cast<Expression> ());
+			var invokedExpr = Expression.Invoke (expr2.Expand(), expr1.Parameters.Cast<Expression> ());
 			return Expression.Lambda<Func<T, bool>>
 				 (Expression.AndAlso (expr1.Body, invokedExpr), expr1.Parameters);
 		}

--- a/src/Tests/LinqKit.Tests.csproj
+++ b/src/Tests/LinqKit.Tests.csproj
@@ -43,6 +43,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PredicateBuilderTest.cs" />
     <Compile Include="ExpressionCombinerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -54,6 +55,9 @@
       <Project>{aec98f52-83f5-488d-99ef-8affe7c9f6e6}</Project>
       <Name>LinqKit</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Tests/PredicateBuilderTest.cs
+++ b/src/Tests/PredicateBuilderTest.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+using LinqKit;
+
+namespace LinqKit.Tests
+{
+    public class PredicateBuilderTest
+    {
+        [Fact]
+        public void InvokeExpressionCombiner()
+        {
+            Expression<Func<Tuple<int, string>, bool>> criteria1 = x => x.Item1 > 1000;
+            Expression<Func<Tuple<int, string>, bool>> criteria2 = y => y.Item2.Contains("a");
+            Expression<Func<Tuple<int, string>, bool>> criteria3 = criteria1.Or(z => criteria2.Invoke(z));
+
+            Assert.Equal(
+                "x => ((x.Item1 > 1000) OrElse x.Item2.Contains(\"a\"))",
+                criteria3.Expand().ToString());
+        }
+    } 
+}


### PR DESCRIPTION
When using PredicateBuider extension methods together with Invoke() expression without first expanding, nested Invoke is created and wrong paramters replaced. Test case is attached.

Without expand the test case result expression is...

```
x => ((x.Item1 > 1000) OrElse z.Item2.Contains("a"))
```
