### PR TITLE
Add support for a .NET 3.5 version of the library.

### DIFF
--- a/src/ExpandableQuery.cs
+++ b/src/ExpandableQuery.cs
@@ -1,85 +1,98 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.Entity.Infrastructure;
 using System.Linq;
 using System.Text;
 using System.Linq.Expressions;
 using System.Collections;
 using System.Threading;
+#if !NET35
+using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
+#endif
 
 namespace LinqKit
 {
-	/// <summary>
-	/// An IQueryable wrapper that allows us to visit the query's expression tree just before LINQ to SQL gets to it.
-	/// This is based on the excellent work of Tomas Petricek: http://tomasp.net/blog/linq-expand.aspx
-	/// </summary>
-	public class ExpandableQuery<T> : IQueryable<T>, IOrderedQueryable<T>, IOrderedQueryable, IDbAsyncEnumerable<T>
-	{
-		readonly ExpandableQueryProvider<T> _provider;
-		readonly IQueryable<T> _inner;
+    /// <summary>
+    /// An IQueryable wrapper that allows us to visit the query's expression tree just before LINQ to SQL gets to it.
+    /// This is based on the excellent work of Tomas Petricek: http://tomasp.net/blog/linq-expand.aspx
+    /// </summary>
+#if NET35
+    public class ExpandableQuery<T> : IQueryable<T>, IOrderedQueryable<T>, IOrderedQueryable
+#else
+    public class ExpandableQuery<T> : IQueryable<T>, IOrderedQueryable<T>, IOrderedQueryable, IDbAsyncEnumerable<T>
+#endif
+    {
+        readonly ExpandableQueryProvider<T> _provider;
+        readonly IQueryable<T> _inner;
 
-		internal IQueryable<T> InnerQuery { get { return _inner; } }			// Original query, that we're wrapping
+        internal IQueryable<T> InnerQuery { get { return _inner; } }			// Original query, that we're wrapping
 
-		internal ExpandableQuery (IQueryable<T> inner)
-		{
-			_inner = inner;
-			_provider = new ExpandableQueryProvider<T> (this);
-		}
+        internal ExpandableQuery(IQueryable<T> inner)
+        {
+            _inner = inner;
+            _provider = new ExpandableQueryProvider<T>(this);
+        }
 
-		Expression IQueryable.Expression { get { return _inner.Expression; } }
-		Type IQueryable.ElementType { get { return typeof (T); } }
-		IQueryProvider IQueryable.Provider { get { return _provider; } }
-		public IEnumerator<T> GetEnumerator () { return _inner.GetEnumerator (); }
-		IEnumerator IEnumerable.GetEnumerator () { return _inner.GetEnumerator (); }
-		public override string ToString() { return _inner.ToString(); }
+        Expression IQueryable.Expression { get { return _inner.Expression; } }
+        Type IQueryable.ElementType { get { return typeof(T); } }
+        IQueryProvider IQueryable.Provider { get { return _provider; } }
+        public IEnumerator<T> GetEnumerator() { return _inner.GetEnumerator(); }
+        IEnumerator IEnumerable.GetEnumerator() { return _inner.GetEnumerator(); }
+        public override string ToString() { return _inner.ToString(); }
 
-		public IDbAsyncEnumerator<T> GetAsyncEnumerator()
-		{
-			var asyncEnumerable = _inner as IDbAsyncEnumerable<T>;
-			if (asyncEnumerable != null)
-				return asyncEnumerable.GetAsyncEnumerator();
-			return new ExpandableDbAsyncEnumerator<T>(_inner.GetEnumerator());
-		}
+#if !NET35
+        public IDbAsyncEnumerator<T> GetAsyncEnumerator()
+        {
+            var asyncEnumerable = _inner as IDbAsyncEnumerable<T>;
+            if (asyncEnumerable != null)
+                return asyncEnumerable.GetAsyncEnumerator();
+            return new ExpandableDbAsyncEnumerator<T>(_inner.GetEnumerator());
+        }
 
-		IDbAsyncEnumerator IDbAsyncEnumerable.GetAsyncEnumerator()
-		{
-			return this.GetAsyncEnumerator();
-		}
-	}
+        IDbAsyncEnumerator IDbAsyncEnumerable.GetAsyncEnumerator()
+        {
+            return this.GetAsyncEnumerator();
+        }
+#endif
+    }
 
-	class ExpandableQueryProvider<T> : IQueryProvider, IDbAsyncQueryProvider
-	{
-		readonly ExpandableQuery<T> _query;
+#if NET35
+    class ExpandableQueryProvider<T> : IQueryProvider
+#else
+    class ExpandableQueryProvider<T> : IQueryProvider, IDbAsyncQueryProvider
+#endif
+    {
+        readonly ExpandableQuery<T> _query;
 
-		internal ExpandableQueryProvider (ExpandableQuery<T> query)
-		{
-			_query = query;
-		}
+        internal ExpandableQueryProvider(ExpandableQuery<T> query)
+        {
+            _query = query;
+        }
 
-		// The following four methods first call ExpressionExpander to visit the expression tree, then call
-		// upon the inner query to do the remaining work.
+        // The following four methods first call ExpressionExpander to visit the expression tree, then call
+        // upon the inner query to do the remaining work.
 
-		IQueryable<TElement> IQueryProvider.CreateQuery<TElement> (Expression expression)
-		{
-			return new ExpandableQuery<TElement> (_query.InnerQuery.Provider.CreateQuery<TElement> (expression.Expand()));
-		}
+        IQueryable<TElement> IQueryProvider.CreateQuery<TElement>(Expression expression)
+        {
+            return new ExpandableQuery<TElement>(_query.InnerQuery.Provider.CreateQuery<TElement>(expression.Expand()));
+        }
 
-		IQueryable IQueryProvider.CreateQuery (Expression expression)
-		{
-			return _query.InnerQuery.Provider.CreateQuery (expression.Expand());
-		}
+        IQueryable IQueryProvider.CreateQuery(Expression expression)
+        {
+            return _query.InnerQuery.Provider.CreateQuery(expression.Expand());
+        }
 
-		TResult IQueryProvider.Execute<TResult> (Expression expression)
-		{
-			return _query.InnerQuery.Provider.Execute<TResult> (expression.Expand());
-		}
+        TResult IQueryProvider.Execute<TResult>(Expression expression)
+        {
+            return _query.InnerQuery.Provider.Execute<TResult>(expression.Expand());
+        }
 
-		object IQueryProvider.Execute (Expression expression)
-		{
-			return _query.InnerQuery.Provider.Execute (expression.Expand());
-		}
+        object IQueryProvider.Execute(Expression expression)
+        {
+            return _query.InnerQuery.Provider.Execute(expression.Expand());
+        }
 
+#if !NET35
 		public Task<object> ExecuteAsync(Expression expression, CancellationToken cancellationToken)
 		{
 			var asyncProvider = _query.InnerQuery.Provider as IDbAsyncQueryProvider;
@@ -95,5 +108,6 @@ namespace LinqKit
 				return asyncProvider.ExecuteAsync<TResult>(expression.Expand(), cancellationToken);
 			return Task.FromResult(_query.InnerQuery.Provider.Execute<TResult>(expression.Expand()));
 		}
-	}
+#endif
+    }
 }

--- a/src/LinqKit.Net35.csproj
+++ b/src/LinqKit.Net35.csproj
@@ -1,0 +1,104 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.21022</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{AEC98F52-83F5-488D-99EF-8AFFE7C9F6E6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>LinqKit</RootNamespace>
+    <AssemblyName>LinqKit</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>LinqKit.snk</AssemblyOriginatorKeyFile>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NET35</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="EntityFramework">
+      <HintPath>packages\EntityFramework.6.0.2\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ExpandableQuery.cs" />
+    <Compile Include="ExpressionExpander.cs" />
+    <Compile Include="ExpressionVisitor.cs" />
+    <Compile Include="Extensions.cs" />
+    <Compile Include="Linq.cs" />
+    <Compile Include="PredicateBuilder.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="LinqKit.snk" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/LinqKit.Net35.sln
+++ b/src/LinqKit.Net35.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinqKit.Net35", "LinqKit.Net35.csproj", "{AEC98F52-83F5-488D-99EF-8AFFE7C9F6E6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{8AA87CBF-C971-46F4-8F5B-CDD1F7756585}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AEC98F52-83F5-488D-99EF-8AFFE7C9F6E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AEC98F52-83F5-488D-99EF-8AFFE7C9F6E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEC98F52-83F5-488D-99EF-8AFFE7C9F6E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AEC98F52-83F5-488D-99EF-8AFFE7C9F6E6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
I have added a .NET35 csproj and some conditional compiling so that the library can support .NET 3.5 (that run on the .NET 2.0 runtime) without touching any logic from the original library.

The disruption on the project's code is minimum (just a few conditional compiling statements where needed) and will compile without issues.

The .NET35 project does not include the AggregatdBalance or ExpandableDbAsyncEnumerator classes, because they heavily rely on .NET 4 features.