### PR TITLE
- added additional Invoke() overloads to support up to 16 parameters …

### DIFF
--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -59,7 +59,86 @@ namespace LinqKit
 			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4);
 		}
 
+  #if !NET35
 
+		public static TResult Invoke<T1, T2, T3, T4, T5, T6, TResult> (
+			this Expression<Func<T1, T2, T3, T4, T5, T6, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, 
+        T6 arg6)
+		{
+			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4, arg5, arg6);
+		}
+
+		public static TResult Invoke<T1, T2, T3, T4, T5, T6, T7, TResult> (
+			this Expression<Func<T1, T2, T3, T4, T5, T6, T7, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, 
+        T6 arg6, T7 arg7)
+		{
+			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+		}
+
+		public static TResult Invoke<T1, T2, T3, T4, T5, T6, T7, T8, TResult> (
+			this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, 
+        T6 arg6, T7 arg7, T8 arg8)
+		{
+			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+		}
+
+		public static TResult Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> (
+			this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, 
+        T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+		{
+			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+		}
+
+		public static TResult Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> (
+			this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, 
+        T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+		{
+			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+		}
+
+		public static TResult Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> (
+			this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, 
+        T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+		{
+			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+		}
+
+		public static TResult Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> (
+			this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, 
+        T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+		{
+			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+		}
+
+		public static TResult Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> (
+			this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, 
+        T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+		{
+			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+		}
+
+		public static TResult Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> (
+			this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, 
+        T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+		{
+			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
+		}
+
+		public static TResult Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> (
+			this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, 
+        T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+		{
+			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+		}
+
+		public static TResult Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> (
+			this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, 
+        T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+		{
+			return expr.Compile ().Invoke (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+		}
+
+  #endif
 
 		public static void ForEach<T> (this IEnumerable<T> source, Action<T> action)
 		{

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.2.0")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
-[assembly: AssemblyInformationalVersion("1.1.2")]
+[assembly: AssemblyVersion("1.1.2.1")]
+[assembly: AssemblyFileVersion("1.1.2.1")]
+[assembly: AssemblyInformationalVersion("1.1.2.1")]


### PR DESCRIPTION
…based on System.Func<> of .NET 4.5, it solves the following issue:

[Why is my LINQ expression with multiple parameters not compiling](http://stackoverflow.com/questions/30938405/why-is-my-linq-expression-with-multiple-parameters-not-compiling)

Please merge it to the original master branch and release a new version. Thanks.