### PR TITLE
Fix for issue #22. Proper expanding of arguments in method calls.

### DIFF
--- a/src/ExpressionExpander.cs
+++ b/src/ExpressionExpander.cs
@@ -48,7 +48,7 @@ namespace LinqKit
 			try
 			{
 				for (int i = 0; i < lambda.Parameters.Count; i++)
-					replaceVars.Add (lambda.Parameters[i], iv.Arguments[i]);
+					replaceVars.Add (lambda.Parameters[i], this.Visit(iv.Arguments[i]));
 			}
 			catch (ArgumentException ex)
 			{
@@ -75,7 +75,7 @@ namespace LinqKit
 				try
 				{
 					for (int i = 0; i < lambda.Parameters.Count; i++)
-						replaceVars.Add (lambda.Parameters[i], m.Arguments[i + 1]);
+						replaceVars.Add (lambda.Parameters[i], this.Visit(m.Arguments[i + 1]));
 				}
 				catch (ArgumentException ex)
 				{

--- a/src/Tests/ExpressionCombinerTest.cs
+++ b/src/Tests/ExpressionCombinerTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using Xunit;
 using LinqKit;
 
@@ -100,7 +101,19 @@ namespace LinqKit.Tests
 
             Assert.Equal(
                 "x => x.Item1.Item2",
-                criteria.Expand().Expand().ToString());
+                criteria.Expand().ToString());
+        }
+
+        [Fact]
+        public void ExpandProcessesArguments()
+        {
+            Expression<Func<Tuple<bool, bool>, bool>> expr1 = x => x.Item1 && x.Item2;
+            Expression<Func<bool, Tuple<bool, bool>>> expr2 = y => new Tuple<bool, bool>(y, y);
+            Expression<Func<bool, bool>> nestedExpression = z => expr1.Invoke(expr2.Invoke(z));
+
+            Assert.Equal(
+                nestedExpression.Expand().ToString(),
+                nestedExpression.Expand().Expand().ToString());
         }
 
 


### PR DESCRIPTION
Resolves #22 with unit test added.
Solution is in visiting argument expression in method call and invocation expression visiting code.
Eliminates need in duplicate Expand() or AsExpandable() calls.