### PR TITLE
Added example for ".And" predicatebuilder to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,22 @@ Here's how to solve the preceding example with PredicateBuilder:
 ```csharp
 IQueryable<Product> SearchProducts (params string[] keywords)
 {
+  var predicate = PredicateBuilder.New<Product>(true);
+
+  foreach (string keyword in keywords)
+  {
+    string temp = keyword;
+    predicate = predicate.And (p => p.Description.Contains (temp));
+  }
+  return dataContext.Products.Where (predicate);
+}
+```
+
+.. and to search for any keyword instead of all keywords (Or instead of And):
+
+```csharp
+IQueryable<Product> SearchProducts (params string[] keywords)
+{
   var predicate = PredicateBuilder.New<Product>();
 
   foreach (string keyword in keywords)


### PR DESCRIPTION
Added an additional example for "And" PredicateBuilder; to help avoid what appears to be a common gotcha - not constructing with the true value as a constructor parameter.