### PR TITLE
Improved handling target Lambda from Property, Method, Compile() method.

### DIFF
--- a/src/LinqKit.Core/ExpressionExpander.cs
+++ b/src/LinqKit.Core/ExpressionExpander.cs
@@ -32,8 +32,7 @@ namespace LinqKit
             if (target.NodeType == ExpressionType.Call)
             {
                 var mc = (MethodCallExpression) target;
-                if (mc.Method.Name == "Compile" &&
-                    mc.Method.DeclaringType?.GetGenericTypeDefinition() == typeof(Expression<>))
+                if (mc.Method.Name == "Compile" && mc.Method.DeclaringType?.GetGenericTypeDefinition() == typeof(Expression<>))
                 {
                     target = mc.Object;
                 }
@@ -98,8 +97,7 @@ namespace LinqKit
                 }
                 catch (ArgumentException ex)
                 {
-                    throw new InvalidOperationException(
-                        "Invoke cannot be called recursively - try using a temporary variable.", ex);
+                    throw new InvalidOperationException("Invoke cannot be called recursively - try using a temporary variable.", ex);
                 }
 
                 return new ExpressionExpander(replaceVars).Visit(lambda.Body);

--- a/src/LinqKit.Core/Utilities/ExpressionHelpers.cs
+++ b/src/LinqKit.Core/Utilities/ExpressionHelpers.cs
@@ -1,0 +1,45 @@
+﻿using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace LinqKit.Utilities
+{
+    internal static class ExpressionHelpers
+    {
+        public static object EvaluateExpression(this Expression expr)
+        {
+            if (expr == null)
+                return null;
+
+            switch (expr.NodeType)
+            {
+                case ExpressionType.Constant:
+                    return ((ConstantExpression)expr).Value;
+
+                case ExpressionType.MemberAccess:
+                {
+                    var member = (MemberExpression) expr;
+
+                    if (member.Member is FieldInfo field)
+                        return field.GetValue(member.Expression.EvaluateExpression());
+
+                    if (member.Member is PropertyInfo property)
+                        return property.GetValue(member.Expression.EvaluateExpression(), null);
+
+                    break;
+                }
+                case ExpressionType.Call:
+                {
+                    var mc = (MethodCallExpression)expr;
+                    var arguments = mc.Arguments.Select(EvaluateExpression).ToArray();
+                    var instance  = mc.Object.EvaluateExpression();
+                    return mc.Method.Invoke(instance, arguments);
+                }
+            }
+
+            var value = Expression.Lambda(expr).Compile().DynamicInvoke();
+            return value;
+        }
+        
+    }
+}

--- a/src/LinqKit.Core/Utilities/ExpressionHelpers.cs
+++ b/src/LinqKit.Core/Utilities/ExpressionHelpers.cs
@@ -9,7 +9,9 @@ namespace LinqKit.Utilities
         public static object EvaluateExpression(this Expression expr)
         {
             if (expr == null)
+            {
                 return null;
+            }
 
             switch (expr.NodeType)
             {
@@ -21,10 +23,14 @@ namespace LinqKit.Utilities
                     var member = (MemberExpression) expr;
 
                     if (member.Member is FieldInfo field)
+                    {
                         return field.GetValue(member.Expression.EvaluateExpression());
+                    }
 
                     if (member.Member is PropertyInfo property)
+                    {
                         return property.GetValue(member.Expression.EvaluateExpression(), null);
+                    }
 
                     break;
                 }
@@ -37,8 +43,7 @@ namespace LinqKit.Utilities
                 }
             }
 
-            var value = Expression.Lambda(expr).Compile().DynamicInvoke();
-            return value;
+            return Expression.Lambda(expr).Compile().DynamicInvoke();
         }
         
     }

--- a/src/LinqKit.Net35/LinqKit.Net35.csproj
+++ b/src/LinqKit.Net35/LinqKit.Net35.csproj
@@ -103,6 +103,9 @@
     <Compile Include="..\LinqKit.Core\PredicateBuilder.cs">
       <Link>PredicateBuilder.cs</Link>
     </Compile>
+    <Compile Include="..\LinqKit.Core\Utilities\ExpressionHelpers.cs">
+      <Link>Utilities\ExpressionHelpers.cs</Link>
+    </Compile>
     <Compile Include="..\LinqKit.Core\Utilities\IntrospectionExtensions.cs">
       <Link>Utilities\IntrospectionExtensions.cs</Link>
     </Compile>

--- a/src/LinqKit.Net45/LinqKit.Net45.csproj
+++ b/src/LinqKit.Net45/LinqKit.Net45.csproj
@@ -114,6 +114,9 @@
     <Compile Include="..\LinqKit.Core\PredicateBuilder.cs">
       <Link>PredicateBuilder.cs</Link>
     </Compile>
+    <Compile Include="..\LinqKit.Core\Utilities\ExpressionHelpers.cs">
+      <Link>Utilities\ExpressionHelpers.cs</Link>
+    </Compile>
     <Compile Include="..\LinqKit.Core\Utilities\IntrospectionExtensions.cs">
       <Link>Utilities\IntrospectionExtensions.cs</Link>
     </Compile>

--- a/tests/LinqKit.Tests.Net452/AsExpandableTests.cs
+++ b/tests/LinqKit.Tests.Net452/AsExpandableTests.cs
@@ -47,5 +47,111 @@ namespace LinqKit.Tests.Net452
             // Verify
             optimizerMock.Verify(o => o(It.IsAny<Expression>()), Times.Once);
         }
+
+        Expression<Func<int, int>> FunctionToExpand()
+        {
+            return i => i * 2;
+        }
+
+        Expression<Func<int, int>> FunctionToExpandWithParameter(int multiplier)
+        {
+            return i => i * multiplier;
+        }
+
+        Expression<Func<int, int>> PropertyToExpand
+        {
+           get { return i => i * 2; }
+        }
+
+        [Fact]
+        public void AsExpandable_Method_Invoke()
+        {
+            // Assign
+            var query = new[] { 1, 2 }.AsQueryable();
+
+            // Act
+            var result = query.AsExpandable()
+                .Select(i => FunctionToExpand().Invoke(i)).ToArray();
+
+            // Assert
+            Assert.Equal(2, result[0]);
+            Assert.Equal(4, result[1]);
+        }
+
+        [Fact]
+        public void AsExpandable_MethodWithParameter_Invoke()
+        {
+            // Assign
+            var query = new[] { 1, 2 }.AsQueryable();
+
+            // Act
+            var result = query.AsExpandable()
+                .Select(i => FunctionToExpandWithParameter(3).Invoke(i)).ToArray();
+
+            // Assert
+            Assert.Equal(3, result[0]);
+            Assert.Equal(6, result[1]);
+        }
+
+        [Fact]
+        public void AsExpandable_Property_Invoke()
+        {
+            // Assign
+            var query = new[] { 1, 2 }.AsQueryable();
+
+            // Act
+            var result = query.AsExpandable()
+                .Select(i => PropertyToExpand.Invoke(i)).ToArray();
+
+            // Assert
+            Assert.Equal(2, result[0]);
+            Assert.Equal(4, result[1]);
+        }
+
+        [Fact]
+        public void AsExpandable_Method_Compile()
+        {
+            // Assign
+            var query = new[] { 1, 2 }.AsQueryable();
+
+            // Act
+            var result = query.AsExpandable()
+                .Select(i => FunctionToExpand().Compile()(i)).ToArray();
+
+            // Assert
+            Assert.Equal(2, result[0]);
+            Assert.Equal(4, result[1]);
+        }
+
+        [Fact]
+        public void AsExpandable_MethodWithParameter_Compile()
+        {
+            // Assign
+            var query = new[] { 1, 2 }.AsQueryable();
+
+            // Act
+            var result = query.AsExpandable()
+                .Select(i => FunctionToExpandWithParameter(3).Compile()(i)).ToArray();
+
+            // Assert
+            Assert.Equal(3, result[0]);
+            Assert.Equal(6, result[1]);
+        }
+
+        [Fact]
+        public void AsExpandable_Property_Compile()
+        {
+            // Assign
+            var query = new[] { 1, 2 }.AsQueryable();
+
+            // Act
+            var result = query.AsExpandable()
+                .Select(i => PropertyToExpand.Compile()(i)).ToArray();
+
+            // Assert
+            Assert.Equal(2, result[0]);
+            Assert.Equal(4, result[1]);
+        }
+
     }
 }


### PR DESCRIPTION
This PR targeted to solve known LINQKit limitations when expression can be expanded only from local variable.
After this fix, these queries are possible.
```cs
var query = from q in query.AsExpandable()
   select new 
    {
        ValueViaMethod = SomeMethod().Invoke(q.Id),
        ValueViaMethodWithparameters = SomeMethodWithParameters(someValue).Invoke(q.Id),
        ValueViaProperty = SomeProperty.Invoke(q.Id)

        // alternative way via Compile

        ValueViaMethodCompile = SomeMethod().Compile()(q.Id),
        ValueViaMethodWithparametersCompile = SomeMethodWithParameters(someValue).Compile()(q.Id),
        ValueViaPropertyCompile = SomeProperty.Compile()(q.Id)
    }
```