### PR TITLE
Not(). Possibility to negate the whole predicate.

### DIFF
--- a/src/LinqKit.Core/ExpressionStarter.cs
+++ b/src/LinqKit.Core/ExpressionStarter.cs
@@ -67,6 +67,16 @@ namespace LinqKit
             return (IsStarted) ? _predicate = Predicate.And(expr2) : Start(expr2);
         }
 
+        /// <summary>Not</summary>
+        public Expression<Func<T, bool>> Not()
+        {
+            if (IsStarted)
+                _predicate = Predicate.Not();
+            else
+                Start(x => false);
+            return _predicate;
+        }
+
         /// <summary> Show predicate string </summary>
         public override string ToString()
         {

--- a/src/LinqKit.Core/ExpressionStarter.cs
+++ b/src/LinqKit.Core/ExpressionStarter.cs
@@ -71,9 +71,13 @@ namespace LinqKit
         public Expression<Func<T, bool>> Not()
         {
             if (IsStarted)
+            {
                 _predicate = Predicate.Not();
+            }
             else
+            {
                 Start(x => false);
+            }
             return _predicate;
         }
 

--- a/src/LinqKit.Core/PredicateBuilder.cs
+++ b/src/LinqKit.Core/PredicateBuilder.cs
@@ -69,6 +69,10 @@ namespace LinqKit
             return Expression.Lambda<Func<T, bool>>(Expression.AndAlso(expr1.Body, expr2Body), expr1.Parameters);
         }
 
+        /// <summary> NOT </summary>
+        public static Expression<Func<T, bool>> Not<T>(this Expression<Func<T, bool>> expr)
+            => Expression.Lambda<Func<T, bool>>(Expression.Not(expr.Body), expr.Parameters);
+
         /// <summary>
         /// Extends the specified source Predicate with another Predicate and the specified PredicateOperator.
         /// </summary>

--- a/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
+++ b/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
@@ -174,5 +174,54 @@ namespace LinqKit.Tests.Net452
             var items = list.Where(predicate).ToList();
             Assert.Empty(items);
         }
+
+        [Fact]
+        public void PredicateBuilder_PredicateNot()
+        {
+            // Arrange
+            Expression<Func<string, bool>> expectedPredicate = s => s == "a";
+            expectedPredicate = expectedPredicate.Not();
+            var predicate = PredicateBuilder.New<string>(s => s == "a");
+
+            // Act
+            predicate.Not();
+
+            // Assert
+            var expected = expectedPredicate.Expand().ToString();
+            var actual = predicate.Expand().ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void PredicateBuilder_PredicateNotAssignment()
+        {
+            // Arrange
+            Expression<Func<string, bool>> expectedPredicate = s => s == "a";
+            expectedPredicate = expectedPredicate.Not();
+            var predicate = PredicateBuilder.New<string>(s => s == "a");
+
+            // Act
+            predicate = predicate.Not();
+
+            // Assert
+            var expected = expectedPredicate.Expand().ToString();
+            var actual = predicate.Expand().ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void PredicateBuilder_PredicateNotUsage()
+        {
+            // Arrange
+            var list = new List<string> { "a", "b", "c" };
+            var predicate = PredicateBuilder.New<string>(s => s == "a");
+
+            // Act
+            predicate = predicate.Not();
+
+            // Assert
+            var items = list.Where(predicate).ToList();
+            Assert.Equal(new[] { "b", "c", }, items);
+        }
     }
 }


### PR DESCRIPTION
Usage:
``` c#
var predicate = PredicateBuilder.New<Product>(true);
predicate = predicate.And(x => x.Discontinued) // Discontinued == true
predicate = predicate.And(x => x.Id > 10) // Discontinued == true && Id > 10
predicate = predicate.Not(); // !(Discontinued == true && Id > 10)
```

I am currently using an implementation that uses Reflection, but this way is better.