### PR TITLE
PredicateBuilder.Create<T>(IEnumerable<T>). Create ExpressionStarter<T> instances with Anonymous Types.

### DIFF
--- a/src/LinqKit.Core/ExpressionStarter.cs
+++ b/src/LinqKit.Core/ExpressionStarter.cs
@@ -67,6 +67,16 @@ namespace LinqKit
             return (IsStarted) ? _predicate = Predicate.And(expr2) : Start(expr2);
         }
 
+        /// <summary>Not</summary>
+        public Expression<Func<T, bool>> Not()
+        {
+            if (IsStarted)
+                _predicate = Predicate.Not();
+            else
+                Start(x => false);
+            return _predicate;
+        }
+
         /// <summary> Show predicate string </summary>
         public override string ToString()
         {

--- a/src/LinqKit.Core/ExpressionStarter.cs
+++ b/src/LinqKit.Core/ExpressionStarter.cs
@@ -67,20 +67,6 @@ namespace LinqKit
             return (IsStarted) ? _predicate = Predicate.And(expr2) : Start(expr2);
         }
 
-        /// <summary>Not</summary>
-        public Expression<Func<T, bool>> Not()
-        {
-            if (IsStarted)
-            {
-                _predicate = Predicate.Not();
-            }
-            else
-            {
-                Start(x => false);
-            }
-            return _predicate;
-        }
-
         /// <summary> Show predicate string </summary>
         public override string ToString()
         {

--- a/src/LinqKit.Core/ExpressionStarter.cs
+++ b/src/LinqKit.Core/ExpressionStarter.cs
@@ -71,9 +71,13 @@ namespace LinqKit
         public Expression<Func<T, bool>> Not()
         {
             if (IsStarted)
+            {
                 _predicate = Predicate.Not();
+            }
             else
+            {
                 Start(x => false);
+            }
             return _predicate;
         }
 

--- a/src/LinqKit.Core/PredicateBuilder.cs
+++ b/src/LinqKit.Core/PredicateBuilder.cs
@@ -90,10 +90,6 @@ namespace LinqKit
             return Expression.Lambda<Func<T, bool>>(Expression.AndAlso(expr1.Body, expr2Body), expr1.Parameters);
         }
 
-        /// <summary> NOT </summary>
-        public static Expression<Func<T, bool>> Not<T>(this Expression<Func<T, bool>> expr)
-            => Expression.Lambda<Func<T, bool>>(Expression.Not(expr.Body), expr.Parameters);
-
         /// <summary>
         /// Extends the specified source Predicate with another Predicate and the specified PredicateOperator.
         /// </summary>

--- a/src/LinqKit.Core/PredicateBuilder.cs
+++ b/src/LinqKit.Core/PredicateBuilder.cs
@@ -69,6 +69,10 @@ namespace LinqKit
             return Expression.Lambda<Func<T, bool>>(Expression.AndAlso(expr1.Body, expr2Body), expr1.Parameters);
         }
 
+        /// <summary> NOT </summary>
+        public static Expression<Func<T, bool>> Not<T>(this Expression<Func<T, bool>> expr)
+            => Expression.Lambda<Func<T, bool>>(Expression.Not(expr.Body), expr.Parameters);
+
         /// <summary>
         /// Extends the specified source Predicate with another Predicate and the specified PredicateOperator.
         /// </summary>

--- a/src/LinqKit.Core/PredicateBuilder.cs
+++ b/src/LinqKit.Core/PredicateBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace LinqKit
@@ -46,6 +47,26 @@ namespace LinqKit
 
         /// <summary> Create an expression with a stub expression true or false to use when the expression is not yet started. </summary>
         public static ExpressionStarter<T> New<T>(bool defaultExpression) { return new ExpressionStarter<T>(defaultExpression); }
+
+        // TODO: Possible better method names : New , NewBy , CreateBy etc.
+        /// <summary>
+        /// Create an expression using an ienumerable.
+        /// May be used to instantiate ExpressionStarter objects with anonymous types.
+        /// </summary>
+        /// <typeparam name="T">The type</typeparam>
+        /// <param name="ienumerable">The value is NOT used. Only serves as a way to provide the generic type.</param>
+        public static ExpressionStarter<T> Create<T>(IEnumerable<T> ienumerable, Expression<Func<T, bool>> expr = null)
+            => PredicateBuilder.New<T>();
+
+        // TODO: Possible better method names : New , NewBy , CreateBy etc.
+        /// <summary>
+        /// Create an expression using an ienumerable with a stub expression true or false to use when the expression is not yet started.
+        /// May be used to instantiate ExpressionStarter objects with anonymous types.
+        /// </summary>
+        /// <typeparam name="T">The type</typeparam>
+        /// <param name="ienumerable">The value is NOT used. Only serves as a way to provide the generic type.</param>
+        public static ExpressionStarter<T> Create<T>(IEnumerable<T> ienumerable, bool defaultExpression)
+            => PredicateBuilder.New<T>(defaultExpression);
 
         /// <summary> Always true </summary>
         [Obsolete("Use PredicateBuilder.New() instead.")]

--- a/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
+++ b/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
@@ -174,5 +174,54 @@ namespace LinqKit.Tests.Net452
             var items = list.Where(predicate).ToList();
             Assert.Empty(items);
         }
+
+        [Fact]
+        public void PredicateBuilder_PredicateNot()
+        {
+            // Arrange
+            Expression<Func<string, bool>> expectedPredicate = s => s == "a";
+            expectedPredicate = expectedPredicate.Not();
+            var predicate = PredicateBuilder.New<string>(s => s == "a");
+
+            // Act
+            predicate.Not();
+
+            // Assert
+            var expected = expectedPredicate.Expand().ToString();
+            var actual = predicate.Expand().ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void PredicateBuilder_PredicateNotAssignment()
+        {
+            // Arrange
+            Expression<Func<string, bool>> expectedPredicate = s => s == "a";
+            expectedPredicate = expectedPredicate.Not();
+            var predicate = PredicateBuilder.New<string>(s => s == "a");
+
+            // Act
+            predicate = predicate.Not();
+
+            // Assert
+            var expected = expectedPredicate.Expand().ToString();
+            var actual = predicate.Expand().ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void PredicateBuilder_PredicateNotUsage()
+        {
+            // Arrange
+            var list = new List<string> { "a", "b", "c" };
+            var predicate = PredicateBuilder.New<string>(s => s == "a");
+
+            // Act
+            predicate = predicate.Not();
+
+            // Assert
+            var items = list.Where(predicate).ToList();
+            Assert.Equal(new[] { "b", "c", }, items);
+        }
     }
 }

--- a/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
+++ b/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
@@ -15,6 +15,51 @@ namespace LinqKit.Tests.Net452
         }
 
         [Fact]
+        public void PredicateBuilder_Create()
+        {
+            var ienumerable = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, }
+                .Select(x => new
+                {
+                    number = x,
+                    squared = x * x,
+                });
+            var predicate = PredicateBuilder.Create(ienumerable);
+            predicate = predicate.Or(x => x.number <= 2);
+            predicate = predicate.Or(x => x.squared >= 64);
+            Assert.Equal("x => ((x.number <= 2) OrElse (x.squared >= 64))", predicate.Expand().ToString());
+        }
+
+        [Fact]
+        public void PredicateBuilder_Create_expr()
+        {
+            var ienumerable = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, }
+                .Select(x => new
+                {
+                    number = x,
+                    squared = x * x,
+                });
+            var predicate = PredicateBuilder.Create(ienumerable, expr: x => false);
+            predicate = predicate.Or(x => x.number <= 2);
+            predicate = predicate.Or(x => x.squared >= 64);
+            Assert.Equal("x => ((x.number <= 2) OrElse (x.squared >= 64))", predicate.Expand().ToString());
+        }
+
+        [Fact]
+        public void PredicateBuilder_Create_defaultExpression()
+        {
+            var ienumerable = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, }
+                .Select(x => new
+                {
+                    number = x,
+                    squared = x * x,
+                });
+            var predicate = PredicateBuilder.Create(ienumerable, defaultExpression: false);
+            predicate = predicate.Or(x => x.number <= 2);
+            predicate = predicate.Or(x => x.squared >= 64);
+            Assert.Equal("x => ((x.number <= 2) OrElse (x.squared >= 64))", predicate.Expand().ToString());
+        }
+
+        [Fact]
         public void PredicateBuilder_Extend()
         {
             Expression<Func<User, bool>> first = x => x.Id1 > 1;

--- a/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
+++ b/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
@@ -219,54 +219,5 @@ namespace LinqKit.Tests.Net452
             var items = list.Where(predicate).ToList();
             Assert.Empty(items);
         }
-
-        [Fact]
-        public void PredicateBuilder_PredicateNot()
-        {
-            // Arrange
-            Expression<Func<string, bool>> expectedPredicate = s => s == "a";
-            expectedPredicate = expectedPredicate.Not();
-            var predicate = PredicateBuilder.New<string>(s => s == "a");
-
-            // Act
-            predicate.Not();
-
-            // Assert
-            var expected = expectedPredicate.Expand().ToString();
-            var actual = predicate.Expand().ToString();
-            Assert.Equal(expected, actual);
-        }
-
-        [Fact]
-        public void PredicateBuilder_PredicateNotAssignment()
-        {
-            // Arrange
-            Expression<Func<string, bool>> expectedPredicate = s => s == "a";
-            expectedPredicate = expectedPredicate.Not();
-            var predicate = PredicateBuilder.New<string>(s => s == "a");
-
-            // Act
-            predicate = predicate.Not();
-
-            // Assert
-            var expected = expectedPredicate.Expand().ToString();
-            var actual = predicate.Expand().ToString();
-            Assert.Equal(expected, actual);
-        }
-
-        [Fact]
-        public void PredicateBuilder_PredicateNotUsage()
-        {
-            // Arrange
-            var list = new List<string> { "a", "b", "c" };
-            var predicate = PredicateBuilder.New<string>(s => s == "a");
-
-            // Act
-            predicate = predicate.Not();
-
-            // Assert
-            var items = list.Where(predicate).ToList();
-            Assert.Equal(new[] { "b", "c", }, items);
-        }
     }
 }


### PR DESCRIPTION
Possibility to create <code>ExpressionStarter</code> instances with <code>Anonymous Types</code>.

Usage:
```csharp
var ienumerable = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, }
    .Select(x => new
    {
        number = x,
        squared = x * x,
    });
var predicate = PredicateBuilder.Create(ienumerable);
predicate = predicate.Or(x => x.number <= 2);
predicate = predicate.Or(x => x.squared >= 64);
```