### PR TITLE
PredicateBuilder.New<T>(IEnumerable<T>)

### DIFF
--- a/src/LinqKit.Core/PredicateBuilder.cs
+++ b/src/LinqKit.Core/PredicateBuilder.cs
@@ -48,24 +48,22 @@ namespace LinqKit
         /// <summary> Create an expression with a stub expression true or false to use when the expression is not yet started. </summary>
         public static ExpressionStarter<T> New<T>(bool defaultExpression) { return new ExpressionStarter<T>(defaultExpression); }
 
-        // TODO: Possible better method names : New , NewBy , CreateBy etc.
         /// <summary>
         /// Create an expression using an ienumerable.
         /// May be used to instantiate ExpressionStarter objects with anonymous types.
         /// </summary>
         /// <typeparam name="T">The type</typeparam>
         /// <param name="ienumerable">The value is NOT used. Only serves as a way to provide the generic type.</param>
-        public static ExpressionStarter<T> Create<T>(IEnumerable<T> ienumerable, Expression<Func<T, bool>> expr = null)
+        public static ExpressionStarter<T> New<T>(IEnumerable<T> ienumerable, Expression<Func<T, bool>> expr = null)
             => PredicateBuilder.New<T>();
 
-        // TODO: Possible better method names : New , NewBy , CreateBy etc.
         /// <summary>
         /// Create an expression using an ienumerable with a stub expression true or false to use when the expression is not yet started.
         /// May be used to instantiate ExpressionStarter objects with anonymous types.
         /// </summary>
         /// <typeparam name="T">The type</typeparam>
         /// <param name="ienumerable">The value is NOT used. Only serves as a way to provide the generic type.</param>
-        public static ExpressionStarter<T> Create<T>(IEnumerable<T> ienumerable, bool defaultExpression)
+        public static ExpressionStarter<T> New<T>(IEnumerable<T> ienumerable, bool defaultExpression)
             => PredicateBuilder.New<T>(defaultExpression);
 
         /// <summary> Always true </summary>

--- a/src/LinqKit.Core/PredicateBuilder.cs
+++ b/src/LinqKit.Core/PredicateBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace LinqKit
@@ -46,6 +47,26 @@ namespace LinqKit
 
         /// <summary> Create an expression with a stub expression true or false to use when the expression is not yet started. </summary>
         public static ExpressionStarter<T> New<T>(bool defaultExpression) { return new ExpressionStarter<T>(defaultExpression); }
+
+        // TODO: Possible better method names : New , NewBy , CreateBy etc.
+        /// <summary>
+        /// Create an expression using an ienumerable.
+        /// May be used to instantiate ExpressionStarter objects with anonymous types.
+        /// </summary>
+        /// <typeparam name="T">The type</typeparam>
+        /// <param name="ienumerable">The value is NOT used. Only serves as a way to provide the generic type.</param>
+        public static ExpressionStarter<T> Create<T>(IEnumerable<T> ienumerable, Expression<Func<T, bool>> expr = null)
+            => PredicateBuilder.New<T>();
+
+        // TODO: Possible better method names : New , NewBy , CreateBy etc.
+        /// <summary>
+        /// Create an expression using an ienumerable with a stub expression true or false to use when the expression is not yet started.
+        /// May be used to instantiate ExpressionStarter objects with anonymous types.
+        /// </summary>
+        /// <typeparam name="T">The type</typeparam>
+        /// <param name="ienumerable">The value is NOT used. Only serves as a way to provide the generic type.</param>
+        public static ExpressionStarter<T> Create<T>(IEnumerable<T> ienumerable, bool defaultExpression)
+            => PredicateBuilder.New<T>(defaultExpression);
 
         /// <summary> Always true </summary>
         [Obsolete("Use PredicateBuilder.New() instead.")]

--- a/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
+++ b/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
@@ -15,45 +15,45 @@ namespace LinqKit.Tests.Net452
         }
 
         [Fact]
-        public void PredicateBuilder_Create()
+        public void PredicateBuilder_New()
         {
-            var ienumerable = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, }
+            var ienumerable = Enumerable.Range(1, 9)
                 .Select(x => new
                 {
                     number = x,
                     squared = x * x,
                 });
-            var predicate = PredicateBuilder.Create(ienumerable);
+            var predicate = PredicateBuilder.New(ienumerable);
             predicate = predicate.Or(x => x.number <= 2);
             predicate = predicate.Or(x => x.squared >= 64);
             Assert.Equal("x => ((x.number <= 2) OrElse (x.squared >= 64))", predicate.Expand().ToString());
         }
 
         [Fact]
-        public void PredicateBuilder_Create_expr()
+        public void PredicateBuilder_New_expr()
         {
-            var ienumerable = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, }
+            var ienumerable = Enumerable.Range(1, 9)
                 .Select(x => new
                 {
                     number = x,
                     squared = x * x,
                 });
-            var predicate = PredicateBuilder.Create(ienumerable, expr: x => false);
+            var predicate = PredicateBuilder.New(ienumerable, expr: x => false);
             predicate = predicate.Or(x => x.number <= 2);
             predicate = predicate.Or(x => x.squared >= 64);
             Assert.Equal("x => ((x.number <= 2) OrElse (x.squared >= 64))", predicate.Expand().ToString());
         }
 
         [Fact]
-        public void PredicateBuilder_Create_defaultExpression()
+        public void PredicateBuilder_New_defaultExpression()
         {
-            var ienumerable = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, }
+            var ienumerable = Enumerable.Range(1, 9)
                 .Select(x => new
                 {
                     number = x,
                     squared = x * x,
                 });
-            var predicate = PredicateBuilder.Create(ienumerable, defaultExpression: false);
+            var predicate = PredicateBuilder.New(ienumerable, defaultExpression: false);
             predicate = predicate.Or(x => x.number <= 2);
             predicate = predicate.Or(x => x.squared >= 64);
             Assert.Equal("x => ((x.number <= 2) OrElse (x.squared >= 64))", predicate.Expand().ToString());

--- a/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
+++ b/tests/LinqKit.Tests.Net452/PredicateBuilderTests.cs
@@ -15,6 +15,51 @@ namespace LinqKit.Tests.Net452
         }
 
         [Fact]
+        public void PredicateBuilder_Create()
+        {
+            var ienumerable = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, }
+                .Select(x => new
+                {
+                    number = x,
+                    squared = x * x,
+                });
+            var predicate = PredicateBuilder.Create(ienumerable);
+            predicate = predicate.Or(x => x.number <= 2);
+            predicate = predicate.Or(x => x.squared >= 64);
+            Assert.Equal("x => ((x.number <= 2) OrElse (x.squared >= 64))", predicate.Expand().ToString());
+        }
+
+        [Fact]
+        public void PredicateBuilder_Create_expr()
+        {
+            var ienumerable = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, }
+                .Select(x => new
+                {
+                    number = x,
+                    squared = x * x,
+                });
+            var predicate = PredicateBuilder.Create(ienumerable, expr: x => false);
+            predicate = predicate.Or(x => x.number <= 2);
+            predicate = predicate.Or(x => x.squared >= 64);
+            Assert.Equal("x => ((x.number <= 2) OrElse (x.squared >= 64))", predicate.Expand().ToString());
+        }
+
+        [Fact]
+        public void PredicateBuilder_Create_defaultExpression()
+        {
+            var ienumerable = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, }
+                .Select(x => new
+                {
+                    number = x,
+                    squared = x * x,
+                });
+            var predicate = PredicateBuilder.Create(ienumerable, defaultExpression: false);
+            predicate = predicate.Or(x => x.number <= 2);
+            predicate = predicate.Or(x => x.squared >= 64);
+            Assert.Equal("x => ((x.number <= 2) OrElse (x.squared >= 64))", predicate.Expand().ToString());
+        }
+
+        [Fact]
         public void PredicateBuilder_Extend()
         {
             Expression<Func<User, bool>> first = x => x.Id1 > 1;


### PR DESCRIPTION
Possibility to create ExpressionStarter<T> instances with Anonymous Types.

Usage:
```csharp
var ienumerable = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, }
    .Select(x => new
    {
        number = x,
        squared = x * x,
    });
var predicate = PredicateBuilder.Create(ienumerable);
predicate = predicate.Or(x => x.number <= 2);
predicate = predicate.Or(x => x.squared >= 64);
```