### PR TITLE
#154 Exclude LinqKit.Core implementation from LinqKit.EntityFramework…

### DIFF
--- a/examples/ConsoleAppNet472/ConsoleAppNet472.csproj
+++ b/examples/ConsoleAppNet472/ConsoleAppNet472.csproj
@@ -162,6 +162,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\LinqKit.Core\LinqKit.Core.csproj">
+      <Project>{fc735db2-5419-4cf3-8aea-8231330a4d85}</Project>
+      <Name>LinqKit.Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\LinqKit.Microsoft.EntityFrameworkCore3\LinqKit.Microsoft.EntityFrameworkCore3.csproj">
       <Project>{f1a582ae-9c3d-4f45-a007-53eb80035704}</Project>
       <Name>LinqKit.Microsoft.EntityFrameworkCore3</Name>

--- a/src/LinqKit.Core/AggregateBalanced.cs
+++ b/src/LinqKit.Core/AggregateBalanced.cs
@@ -1,4 +1,5 @@
-﻿#if !(NET35 || NOASYNCPROVIDER)
+﻿#if NOEF
+#if !(NET35 || NOASYNCPROVIDER)
 using LinqKit.Utilities;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -103,4 +104,5 @@ namespace System.Linq
         }
     }
 }
+#endif
 #endif

--- a/src/LinqKit.Core/ExpandableQuery.cs
+++ b/src/LinqKit.Core/ExpandableQuery.cs
@@ -16,7 +16,11 @@ using System.Data.Entity.Infrastructure;
 #endif
 #endif
 
+#if NOEF
+namespace LinqKit.Core
+#else
 namespace LinqKit
+#endif
 {
     /// <summary>
     /// An IQueryable wrapper that allows us to visit the query's expression tree just before LINQ to SQL gets to it.

--- a/src/LinqKit.Core/ExpressionExpander.cs
+++ b/src/LinqKit.Core/ExpressionExpander.cs
@@ -1,15 +1,17 @@
-﻿using System;
+﻿#if NOEF
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 
 namespace LinqKit
 {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     /// <summary>
     /// Custom expresssion visitor for ExpandableQuery. This expands calls to Expression.Compile() and
     /// collapses captured lambda references in subqueries which LINQ to SQL can't otherwise handle.
     /// </summary>
-    class ExpressionExpander : ExpressionVisitor
+    public class ExpressionExpander : ExpressionVisitor
     {
         // Replacement parameters - for when invoking a lambda expression.
         readonly Dictionary<ParameterExpression, Expression> _replaceVars;
@@ -59,7 +61,7 @@ namespace LinqKit
 
         protected override Expression VisitMethodCall(MethodCallExpression m)
         {
-            if (m.Method.Name == "Invoke" && m.Method.DeclaringType == typeof(Extensions))
+            if (m.Method.Name == nameof(ExtensionsCore.Invoke) && m.Method.DeclaringType == typeof(ExtensionsCore))
             {
                 var target = m.Arguments[0];
                 if (target is MemberExpression)
@@ -98,7 +100,7 @@ namespace LinqKit
             }
 
             // Expand calls to an expression's Compile() method:
-            if (m.Method.Name == "Compile" && m.Object is MemberExpression)
+            if (m.Method.Name == nameof(LambdaExpression.Compile) && m.Object is MemberExpression)
             {
                 var me = (MemberExpression)m.Object;
                 var newExpr = TransformExpr(me);
@@ -109,7 +111,7 @@ namespace LinqKit
             }
 
             // Strip out any nested calls to AsExpandable():
-            if (m.Method.Name == "AsExpandable" && m.Method.DeclaringType == typeof(Extensions))
+            if (m.Method.Name == nameof(Core.Extensions.AsExpandable) && m.Method.DeclaringType.Name == nameof(Core.Extensions) && m.Method.DeclaringType.Namespace.StartsWith("LinqKit"))
             {
                 return m.Arguments[0];
             }
@@ -197,4 +199,6 @@ namespace LinqKit
             return input;
         }
     }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }
+#endif

--- a/src/LinqKit.Core/ExpressionStarter.cs
+++ b/src/LinqKit.Core/ExpressionStarter.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿#if NOEF
+using JetBrains.Annotations;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq.Expressions;
@@ -73,7 +74,7 @@ namespace LinqKit
             return Predicate == null ? null : Predicate.ToString();
         }
 
-        #region Implicit Operators
+#region Implicit Operators
         /// <summary>
         /// Allows this object to be implicitely converted to an Expression{Func{T, bool}}.
         /// </summary>
@@ -100,9 +101,9 @@ namespace LinqKit
         {
             return right == null ? null : new ExpressionStarter<T>(right);
         }
-        #endregion
+#endregion
 
-        #region Implement Expression<TDelagate> methods and properties
+#region Implement Expression<TDelagate> methods and properties
 #if !(NET35)
 
         /// <summary></summary>
@@ -116,9 +117,9 @@ namespace LinqKit
         /// <summary></summary>
         public Expression<Func<T, bool>> Update(Expression body, IEnumerable<ParameterExpression> parameters) { return Predicate.Update(body, parameters); }
 #endif
-        #endregion
+#endregion
 
-        #region Implement LamdaExpression methods and properties
+#region Implement LamdaExpression methods and properties
 
         /// <summary></summary>
         public Expression Body => Predicate.Body;
@@ -152,13 +153,14 @@ namespace LinqKit
         public void CompileToMethod(MethodBuilder method, DebugInfoGenerator debugInfoGenerator) { Predicate.CompileToMethod(method, debugInfoGenerator); }
 
 #endif
-        #endregion
+#endregion
 
-        #region Implement Expression methods and properties
+#region Implement Expression methods and properties
 #if !(NET35)
         /// <summary></summary>
         public virtual bool CanReduce => Predicate.CanReduce;
 #endif
-        #endregion
+#endregion
     }
 }
+#endif

--- a/src/LinqKit.Core/ExpressionVisitor.cs
+++ b/src/LinqKit.Core/ExpressionVisitor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NOEF
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq.Expressions;
@@ -383,3 +384,4 @@ namespace LinqKit
         }
     }
 }
+#endif

--- a/src/LinqKit.Core/Linq.cs
+++ b/src/LinqKit.Core/Linq.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NOEF
+using System;
 using System.Linq.Expressions;
 
 namespace LinqKit
@@ -58,3 +59,4 @@ namespace LinqKit
         }
     }
 }
+#endif

--- a/src/LinqKit.Core/LinqKit.Core.csproj
+++ b/src/LinqKit.Core/LinqKit.Core.csproj
@@ -29,6 +29,49 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>
+        LinqKit, PublicKey=002400000480000094000000060200000024000052534131000400000100010009af226acf80fc92af220b3e8080830297eeb9711ca1d8cf2a567c211dfdae8bd2fd7e37777b3d0368e8b6c4ed7252ad4f19f3eb38a3f26a0bbc7016d064bf0a111a40058e97239c11d8c2cdc1e93367f862a5e0166253463f90adba77c183cc8334d07198b8e80c69022f9bc6b260de3b1753c33b587e8c51175e1f6a1152d2
+      </_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>
+        LinqKit.EntityFramework, PublicKey=00240000048000009400000006020000002400005253413100040000010001009520f2954a09e74f547e940936cfc0f56d807290d1294c235fd2013f1de9afd650da9e862e6349857c80e619b9ea119546b0e9a8cbd700d6f5cbbf5709a1fee527c9b6c1ece7ef6f1d45dcb5b8a23d3a9483ab49d5254affd7b894aaa494b28e8b98ae54dfc802737cf5c5035d3507f4bf8c3877d86709ae9c615ebe089621b5
+      </_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>
+        LinqKit.Microsoft.EntityFrameworkCore, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f77c6bb1a3b2c5b07d843b1c9b845dffcce043e3711d17877ed730ad2e53983b3ed7c1346673cc9d3953a430334fa3c8ce73430ef58a930de917f6d34251a145f4f267d535ea2f797e717d7ce9684711888cc788cf71b4c03b531f52a88ab70e52b6e1fb783f0ef8b0c6afe55b573bf3f4982088325448aef8f3b1fea5d5a7c8
+      </_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>
+        LinqKit.Microsoft.EntityFrameworkCore2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f77c6bb1a3b2c5b07d843b1c9b845dffcce043e3711d17877ed730ad2e53983b3ed7c1346673cc9d3953a430334fa3c8ce73430ef58a930de917f6d34251a145f4f267d535ea2f797e717d7ce9684711888cc788cf71b4c03b531f52a88ab70e52b6e1fb783f0ef8b0c6afe55b573bf3f4982088325448aef8f3b1fea5d5a7c8
+      </_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>
+        LinqKit.Microsoft.EntityFrameworkCore3, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f77c6bb1a3b2c5b07d843b1c9b845dffcce043e3711d17877ed730ad2e53983b3ed7c1346673cc9d3953a430334fa3c8ce73430ef58a930de917f6d34251a145f4f267d535ea2f797e717d7ce9684711888cc788cf71b4c03b531f52a88ab70e52b6e1fb783f0ef8b0c6afe55b573bf3f4982088325448aef8f3b1fea5d5a7c8
+      </_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>
+        LinqKit.Net35, PublicKey=002400000480000094000000060200000024000052534131000400000100010009af226acf80fc92af220b3e8080830297eeb9711ca1d8cf2a567c211dfdae8bd2fd7e37777b3d0368e8b6c4ed7252ad4f19f3eb38a3f26a0bbc7016d064bf0a111a40058e97239c11d8c2cdc1e93367f862a5e0166253463f90adba77c183cc8334d07198b8e80c69022f9bc6b260de3b1753c33b587e8c51175e1f6a1152d2
+      </_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>
+        LinqKit.Net45, PublicKey=002400000480000094000000060200000024000052534131000400000100010009af226acf80fc92af220b3e8080830297eeb9711ca1d8cf2a567c211dfdae8bd2fd7e37777b3d0368e8b6c4ed7252ad4f19f3eb38a3f26a0bbc7016d064bf0a111a40058e97239c11d8c2cdc1e93367f862a5e0166253463f90adba77c183cc8334d07198b8e80c69022f9bc6b260de3b1753c33b587e8c51175e1f6a1152d2
+      </_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>
+        LinqKit.Z.EntityFramework.Classic, PublicKey=00240000048000009400000006020000002400005253413100040000010001009520f2954a09e74f547e940936cfc0f56d807290d1294c235fd2013f1de9afd650da9e862e6349857c80e619b9ea119546b0e9a8cbd700d6f5cbbf5709a1fee527c9b6c1ece7ef6f1d45dcb5b8a23d3a9483ab49d5254affd7b894aaa494b28e8b98ae54dfc802737cf5c5035d3507f4bf8c3877d86709ae9c615ebe089621b5
+      </_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <PackageReference Include="JetBrains.Annotations" Version="10.0.0">
       <PrivateAssets>All</PrivateAssets>
@@ -128,7 +171,7 @@
     <NugetTargetMoniker>.NETPortable,Version=v0.0,Profile=Profile328</NugetTargetMoniker>
     <LanguageTargets>$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets</LanguageTargets>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'portable-net45+win8+wpa81+wp8'">
     <DefineConstants>$(DefineConstants);PORTABLE</DefineConstants>
     <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>

--- a/src/LinqKit.Core/LinqKitExtension.cs
+++ b/src/LinqKit.Core/LinqKitExtension.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NOEF
+using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
@@ -18,3 +19,4 @@ namespace LinqKit
         public static Func<Expression, Expression> QueryOptimizer = e => e;
     }
 }
+#endif

--- a/src/LinqKit.Core/PredicateBuilder.cs
+++ b/src/LinqKit.Core/PredicateBuilder.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿#if NOEF
+using JetBrains.Annotations;
 using System;
 using System.Linq.Expressions;
 
@@ -96,3 +97,4 @@ namespace LinqKit
         }
     }
 }
+#endif

--- a/src/LinqKit.EntityFramework/ExtensionsEF.cs
+++ b/src/LinqKit.EntityFramework/ExtensionsEF.cs
@@ -34,21 +34,21 @@ namespace LinqKit
         [PublicAPI]
         public static TResult InvokeEF<TResult>(this Expression<Func<TResult>> expr)
         {
-            return Extensions.Invoke(expr);
+            return ExtensionsCore.Invoke(expr);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
         [PublicAPI]
         public static TResult InvokeEF<T1, TResult>(this Expression<Func<T1, TResult>> expr, T1 arg1)
         {
-            return Extensions.Invoke(expr, arg1);
+            return ExtensionsCore.Invoke(expr, arg1);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
         [PublicAPI]
         public static TResult InvokeEF<T1, T2, TResult>(this Expression<Func<T1, T2, TResult>> expr, T1 arg1, T2 arg2)
         {
-            return Extensions.Invoke(expr, arg1, arg2);
+            return ExtensionsCore.Invoke(expr, arg1, arg2);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -56,7 +56,7 @@ namespace LinqKit
         public static TResult InvokeEF<T1, T2, T3, TResult>(
             this Expression<Func<T1, T2, T3, TResult>> expr, T1 arg1, T2 arg2, T3 arg3)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -64,7 +64,7 @@ namespace LinqKit
         public static TResult InvokeEF<T1, T2, T3, T4, TResult>(
             this Expression<Func<T1, T2, T3, T4, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4);
         }
 
 #if !(NET35 || NET40)
@@ -73,7 +73,7 @@ namespace LinqKit
         public static TResult InvokeEF<T1, T2, T3, T4, T5, TResult>(
             this Expression<Func<T1, T2, T3, T4, T5, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -82,7 +82,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -91,7 +91,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -100,7 +100,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -109,7 +109,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -118,7 +118,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -127,7 +127,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -136,7 +136,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -145,7 +145,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -154,7 +154,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -163,7 +163,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -172,7 +172,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
         }
 #endif
     }

--- a/src/LinqKit.EntityFramework/LinqKit.EntityFramework.csproj
+++ b/src/LinqKit.EntityFramework/LinqKit.EntityFramework.csproj
@@ -49,4 +49,8 @@
     <PackageReference Include="EntityFramework" Version="6.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\LinqKit.Core\LinqKit.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/LinqKit.Microsoft.EntityFrameworkCore/ExtensionsEFCore.cs
+++ b/src/LinqKit.Microsoft.EntityFrameworkCore/ExtensionsEFCore.cs
@@ -33,21 +33,21 @@ namespace LinqKit
         [PublicAPI]
         public static TResult InvokeEFCore<TResult>(this Expression<Func<TResult>> expr)
         {
-            return Extensions.Invoke(expr);
+            return ExtensionsCore.Invoke(expr);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
         [PublicAPI]
         public static TResult InvokeEFCore<T1, TResult>(this Expression<Func<T1, TResult>> expr, T1 arg1)
         {
-            return Extensions.Invoke(expr, arg1);
+            return ExtensionsCore.Invoke(expr, arg1);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
         [PublicAPI]
         public static TResult InvokeEFCore<T1, T2, TResult>(this Expression<Func<T1, T2, TResult>> expr, T1 arg1, T2 arg2)
         {
-            return Extensions.Invoke(expr, arg1, arg2);
+            return ExtensionsCore.Invoke(expr, arg1, arg2);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -55,7 +55,7 @@ namespace LinqKit
         public static TResult InvokeEFCore<T1, T2, T3, TResult>(
             this Expression<Func<T1, T2, T3, TResult>> expr, T1 arg1, T2 arg2, T3 arg3)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -63,7 +63,7 @@ namespace LinqKit
         public static TResult InvokeEFCore<T1, T2, T3, T4, TResult>(
             this Expression<Func<T1, T2, T3, T4, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -71,7 +71,7 @@ namespace LinqKit
         public static TResult InvokeEFCore<T1, T2, T3, T4, T5, TResult>(
             this Expression<Func<T1, T2, T3, T4, T5, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -80,7 +80,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -89,7 +89,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -98,7 +98,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -107,7 +107,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -116,7 +116,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -125,7 +125,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -134,7 +134,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -143,7 +143,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -152,7 +152,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -161,7 +161,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
         }
 
         /// <summary>LinqKit: Compile and invoke</summary>
@@ -170,7 +170,7 @@ namespace LinqKit
             this Expression<Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>> expr, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
         T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
-            return Extensions.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+            return ExtensionsCore.Invoke(expr, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
         }
     }
 }

--- a/src/LinqKit.Microsoft.EntityFrameworkCore/LinqKit.Microsoft.EntityFrameworkCore.csproj
+++ b/src/LinqKit.Microsoft.EntityFrameworkCore/LinqKit.Microsoft.EntityFrameworkCore.csproj
@@ -52,4 +52,8 @@
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\LinqKit.Core\LinqKit.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/LinqKit.Microsoft.EntityFrameworkCore2/LinqKit.Microsoft.EntityFrameworkCore2.csproj
+++ b/src/LinqKit.Microsoft.EntityFrameworkCore2/LinqKit.Microsoft.EntityFrameworkCore2.csproj
@@ -40,4 +40,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\LinqKit.Core\LinqKit.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/LinqKit.Microsoft.EntityFrameworkCore3/LinqKit.Microsoft.EntityFrameworkCore3.csproj
+++ b/src/LinqKit.Microsoft.EntityFrameworkCore3/LinqKit.Microsoft.EntityFrameworkCore3.csproj
@@ -46,4 +46,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\LinqKit.Core\LinqKit.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/LinqKit.Net35/LinqKit.Net35.csproj
+++ b/src/LinqKit.Net35/LinqKit.Net35.csproj
@@ -13,8 +13,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>
-    </AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>..\LinqKit.Net45\LinqKit.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>
@@ -122,6 +121,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LinqKit.Core\LinqKit.Core.csproj">
+      <Project>{fc735db2-5419-4cf3-8aea-8231330a4d85}</Project>
+      <Name>LinqKit.Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/LinqKit.Net45/LinqKit.Net45.csproj
+++ b/src/LinqKit.Net45/LinqKit.Net45.csproj
@@ -139,6 +139,12 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LinqKit.Core\LinqKit.Core.csproj">
+      <Project>{fc735db2-5419-4cf3-8aea-8231330a4d85}</Project>
+      <Name>LinqKit.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/LinqKit.Z.EntityFramework.Classic/LinqKit.Z.EntityFramework.Classic.csproj
+++ b/src/LinqKit.Z.EntityFramework.Classic/LinqKit.Z.EntityFramework.Classic.csproj
@@ -45,4 +45,8 @@
     <PackageReference Include="Z.EntityFramework.Classic" Version="7.0.40" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\LinqKit.Core\LinqKit.Core.csproj" />
+  </ItemGroup>
+
   </Project>

--- a/src/LinqKit/LinqKit.csproj
+++ b/src/LinqKit/LinqKit.csproj
@@ -50,4 +50,8 @@
     <PackageReference Include="EntityFramework" Version="6.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\LinqKit.Core\LinqKit.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tests/LinqKit.Tests.Net452/LinqKit.Tests.Net452.csproj
+++ b/tests/LinqKit.Tests.Net452/LinqKit.Tests.Net452.csproj
@@ -89,6 +89,10 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\LinqKit.Core\LinqKit.Core.csproj">
+      <Project>{fc735db2-5419-4cf3-8aea-8231330a4d85}</Project>
+      <Name>LinqKit.Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\LinqKit\LinqKit.csproj">
       <Project>{667345ee-b154-432f-a908-cb6374805c20}</Project>
       <Name>LinqKit</Name>


### PR DESCRIPTION
… etc. projects, use ProjectReference converted to package dependency instead