### PR TITLE
Simplify LeftJoin-extension

### DIFF
--- a/tests/LinqKit.Microsoft.EntityFrameworkCore.TestFiles/ExtensionsCoreTests.cs
+++ b/tests/LinqKit.Microsoft.EntityFrameworkCore.TestFiles/ExtensionsCoreTests.cs
@@ -1,0 +1,46 @@
+﻿using FluentAssertions;
+using LinqKit.Microsoft.EntityFrameworkCore.Tests.Model;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LinqKit.Microsoft.EntityFrameworkCore.Tests
+{
+    public class ExtensionsCoreTests
+    {
+
+        [Fact]
+        public void LeftJoinTest()
+        {
+            var builder = new DbContextOptionsBuilder<TestContext>();
+            builder
+                .UseSqlite("DataSource=testdb;mode=memory");
+
+            using (var context = new TestContext(builder.Options))
+            {
+                context.Database.OpenConnection();
+                context.Database.EnsureCreated();
+
+                context.TestEntities.Add(new TestEntity {Id = 1, Value = "One"});
+                context.TestEntities.Add(new TestEntity {Id = 2, ParentId = 1, Value = "Two"});
+                context.SaveChanges();
+
+                context.TestEntities.LeftJoin(
+                        context.TestEntities,
+                        entity => entity.ParentId,
+                        parentEntity => parentEntity.Id,
+                        (entity, parentEntity) => new
+                        {
+                            entity.Value,
+                            ParentValue = parentEntity == null ? null : parentEntity.Value
+                        })
+                    .Should()
+                    .BeEquivalentTo(new[]
+                    {
+                        new {Value = "One", ParentValue = (string) null},
+                        new {Value = "Two", ParentValue = "One"}
+                    }, string.Empty); //message is to select the generic overload
+            }
+        }
+
+    }
+}

--- a/tests/LinqKit.Microsoft.EntityFrameworkCore.TestFiles/Model/TestEntity.cs
+++ b/tests/LinqKit.Microsoft.EntityFrameworkCore.TestFiles/Model/TestEntity.cs
@@ -3,6 +3,7 @@
     public class TestEntity
     {
         public int Id { get; set; }
+        public int? ParentId { get; set; }
         public string Value { get; set; }
     }
 }


### PR DESCRIPTION
This should archive the same result, but would be way more readable. Also it doesn't require reflection.

It may also be possible to merge the remapping from a separate Select into the SelectMany, but I don't know, if this is something EF (Core) would always understand right.