### PR TITLE
Use System.Linq.Expressions.ExpressionVisitor where available

### DIFF
--- a/src/LinqKit.Core/ExpressionExpander.cs
+++ b/src/LinqKit.Core/ExpressionExpander.cs
@@ -174,7 +174,7 @@ namespace LinqKit
             return base.VisitMethodCall(m);
         }
 
-        protected override Expression VisitMemberAccess(MemberExpression m)
+        protected override Expression VisitMember(MemberExpression m)
         {
             if (GetExpandLambda(m.Member, out var methodLambda))
             {
@@ -186,7 +186,7 @@ namespace LinqKit
             // Strip out any references to expressions captured by outer variables - LINQ to SQL can't handle these:
             return m.Member.DeclaringType != null && m.Member.DeclaringType.Name.StartsWith("<>") ?
                 TransformExpr(m)
-                : base.VisitMemberAccess(m);
+                : base.VisitMember(m);
         }
 
         Expression TransformExpr(MemberExpression input)

--- a/src/LinqKit.Net35/LinqKit.Net35.csproj
+++ b/src/LinqKit.Net35/LinqKit.Net35.csproj
@@ -92,7 +92,7 @@
     <Compile Include="..\LinqKit.Core\ExpressionStarter.cs">
       <Link>ExpressionStarter.cs</Link>
     </Compile>
-    <Compile Include="..\LinqKit.Core\ExpressionVisitor.cs">
+    <Compile Include="..\LinqKit.Core\Compatibility\ExpressionVisitor.cs">
       <Link>ExpressionVisitor.cs</Link>
     </Compile>
     <Compile Include="..\LinqKit.Core\Extensions.cs">

--- a/src/LinqKit.Net45/LinqKit.Net45.csproj
+++ b/src/LinqKit.Net45/LinqKit.Net45.csproj
@@ -104,9 +104,6 @@
     <Compile Include="..\LinqKit.Core\ExpressionStarter.cs">
       <Link>ExpressionStarter.cs</Link>
     </Compile>
-    <Compile Include="..\LinqKit.Core\ExpressionVisitor.cs">
-      <Link>ExpressionVisitor.cs</Link>
-    </Compile>
     <Compile Include="..\LinqKit.Core\Extensions.cs">
       <Link>Extensions.cs</Link>
     </Compile>


### PR DESCRIPTION
Addresses #122. This also adds support for e.g. Block and Throw expressions, where they are available, making this PR supersede #178.

I tried to build upon the 'expression-visitor'-branch, but found that the visitor-method `VisitMemberAccess` needs to be renamed to `VisitMember` to be able to get a working library. I wish they had chosen `VisitMemberAccess`, as it better communicates what happens, but they didn't.